### PR TITLE
Fix inkscape rendering

### DIFF
--- a/PILSVG/SVG.py
+++ b/PILSVG/SVG.py
@@ -289,9 +289,6 @@ class SVG:
         except FileNotFoundError:
             raise FileNotFoundError("Please make sure inkscape is installed and has been added to the PATH")
 
-        pipe.stdout.readline()
-        pipe.stdout.readline()
-
         return Image.open(pipe.stdout)
 
     def __im(self, size: Tuple[int, int], margin: int = None, area: str = 'page', renderer: str = 'skia') -> Image.Image:


### PR DESCRIPTION
Attempting to run the command:
`pillow-svg --renderer=inkscape`

was giving me the following error:
```
Traceback (most recent call last):
  File "/Users/srs/Desktop/pyimgtest/venv/bin/pillow-svg", line 8, in <module>
    sys.exit(main())
  File "/Users/srs/Desktop/pyimgtest/venv/lib/python3.9/site-packages/PILSVG/CMD.py", line 95, in main
    SVG.EXPORT(path, stem, format=args.format, dpi=args.dpi,
  File "/Users/srs/Desktop/pyimgtest/venv/lib/python3.9/site-packages/PILSVG/SVG.py", line 475, in EXPORT
    cls(fp).export(stem, format, dpi, size, margin, area, filter, renderer)
  File "/Users/srs/Desktop/pyimgtest/venv/lib/python3.9/site-packages/PILSVG/SVG.py", line 435, in export
    img = self.im(dpi, size, margin, area, filter, renderer=renderer)
  File "/Users/srs/Desktop/pyimgtest/venv/lib/python3.9/site-packages/PILSVG/SVG.py", line 403, in im
    return self.__im(size[0], margin, area, renderer=renderer)
  File "/Users/srs/Desktop/pyimgtest/venv/lib/python3.9/site-packages/PILSVG/SVG.py", line 305, in __im
    return self.__im_inkscape(size, margin, area)
  File "/Users/srs/Desktop/pyimgtest/venv/lib/python3.9/site-packages/PILSVG/SVG.py", line 296, in __im_inkscape
    return Image.open(pipe.stdout)
  File "/Users/srs/Desktop/pyimgtest/venv/lib/python3.9/site-packages/PIL/Image.py", line 3536, in open
    raise UnidentifiedImageError(msg)
PIL.UnidentifiedImageError: cannot identify image file <_io.BytesIO object at 0x105a621d0>
```

Printing out the Inkscape command and running it by hand was working fine:
`print(" ".join(options))`
`inkscape --export-filename=- --export-type=png --export-area-page --export-width=261 --export-height=66 /Users/srs/Desktop/pyimgtest/two.svg`

After some debugging, I fixed it by removing the two calls to `pipe.stdout.readline()` in the `__im_inkscape` function, and now the library is working correctly for me.

I'm not sure why those calls were there to begin with... possibly the author's inkscape binary was printing some strings to stdout before the image itself?